### PR TITLE
implement #first method

### DIFF
--- a/lib/dir_model/import.rb
+++ b/lib/dir_model/import.rb
@@ -95,6 +95,8 @@ module DirModel
       else
         self.class.options[:regex].call
       end
+    rescue NameError
+      instance_exec(&self.class.options[:regex])
     end
   end
 end

--- a/lib/dir_model/import/dir.rb
+++ b/lib/dir_model/import/dir.rb
@@ -46,6 +46,12 @@ module DirModel
         current_dir_model
       end
 
+      def first(context={})
+        each(context).next
+      rescue StopIteration
+        nil
+      end
+
       private
 
       def skip?

--- a/spec/dir_model/units/import/dir_spec.rb
+++ b/spec/dir_model/units/import/dir_spec.rb
@@ -21,6 +21,37 @@ describe DirModel::Import::Dir do
     ]
   end
 
+  describe "#first" do
+    let(:model_class) do
+      Class.new do
+        include DirModel::Model
+        include DirModel::Import
+
+        file :image, regex: -> { /Zones\/Sector_#{sector_name}\/Zone_(?<zone_id>.*)\.(?<extension>png|jpg)/i }
+
+        def sector_name
+          context.sector_name
+        end
+      end
+    end
+
+    let(:instance) { described_class.new source_path, model_class, sector_name: 1 }
+
+    subject { instance.first }
+
+    it "returns the first file found" do
+      expect(subject.source_path).to eql "spec/fixtures/unzip_dir/zones/sector_1/zone_1.png"
+    end
+
+    context "with no first" do
+      let(:source_path) { 'some_invalid_dir' }
+
+      it "returns nil" do
+        expect(subject).to eql nil
+      end
+    end
+  end
+
   # describe '#context' do
   #   it 'symbolizes the context' do
   #     expect(instance.context[:some_context]).to eql(true)

--- a/spec/dir_model/units/import_spec.rb
+++ b/spec/dir_model/units/import_spec.rb
@@ -49,4 +49,20 @@ describe DirModel::Import do
     end
   end
 
+  describe "#get_regexp" do
+    subject { instance.send(:get_regexp) }
+
+    context "when proc that implements #instance_exec" do
+      before do
+        klass.class_eval do
+          file :blah, regex: -> { /some_#{custom}_stuff/ }
+          def custom; "waka" end
+        end
+      end
+
+      it "calls instance exec to generate the regex" do
+        expect(subject.to_s).to eql "(?-mix:some_waka_stuff)"
+      end
+    end
+  end
 end


### PR DESCRIPTION
related to: #14. kind of like the last code sample:

``` ruby
ImportDir.new(file_path, ImportDirModel).where(zone_name: "some zone_name").each {}
```

but looks not as nice by passing in the context.
